### PR TITLE
Lack of ratelimiting   ampache

### DIFF
--- a/bounties/packagist/ampache/1/README.md
+++ b/bounties/packagist/ampache/1/README.md
@@ -1,0 +1,17 @@
+## ✍️ Description
+Lack of RateLimiting in the login page of ampache.
+## 🕵️‍♂️ Proof of Concept 
+* clone the github repo 
+* setted up ampache platform to reproduce the vulnerability
+* I used an intruder in BURP SUITE to test for rate limiting on the password field.
+* It shows 200 OK for wrong information and if password matches BURP show a 302 status code.(even with high thread and without throttle)
+## 💥 Impact
+The attacker is able to perform bruteforce attack to login into victim account.
+## ✅ Checklist
+- [x] _Created and populated the README.md and vulnerability.json files_
+- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
+- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
+- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
+- [x] _Checked that the vulnerability affects the latest version of the package released_
+- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
+- [x] _Complied with all applicable laws_

--- a/bounties/packagist/ampache/1/README.md
+++ b/bounties/packagist/ampache/1/README.md
@@ -5,6 +5,9 @@ Lack of RateLimiting in the login page of ampache.
 * setted up ampache platform to reproduce the vulnerability
 * I used an intruder in BURP SUITE to test for rate limiting on the password field.
 * It shows 200 OK for wrong information and if password matches BURP show a 302 status code.(even with high thread and without throttle)
+
+* https://drive.google.com/file/d/1MOzGvpLTdl84cEqwrA6MtrTWudjnRiYF/view?usp=sharing
+
 ## 💥 Impact
 The attacker is able to perform bruteforce attack to login into victim account.
 ## ✅ Checklist

--- a/bounties/packagist/ampache/1/README.md
+++ b/bounties/packagist/ampache/1/README.md
@@ -1,6 +1,6 @@
-## ✍️ Description
+## Description
 Lack of RateLimiting in the login page of ampache.
-## 🕵️‍♂️ Proof of Concept 
+## Proof of Concept 
 * clone the github repo 
 * setted up ampache platform to reproduce the vulnerability
 * I used an intruder in BURP SUITE to test for rate limiting on the password field.
@@ -8,9 +8,9 @@ Lack of RateLimiting in the login page of ampache.
 
 * https://drive.google.com/file/d/1MOzGvpLTdl84cEqwrA6MtrTWudjnRiYF/view?usp=sharing
 
-## 💥 Impact
+## Impact
 The attacker is able to perform bruteforce attack to login into victim account.
-## ✅ Checklist
+## Checklist
 - [x] _Created and populated the README.md and vulnerability.json files_
 - [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
 - [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_

--- a/bounties/packagist/ampache/1/vulnerability.json
+++ b/bounties/packagist/ampache/1/vulnerability.json
@@ -48,7 +48,7 @@
         "Stars": 2503
     },
     "Permalinks": [
-        ""
+        "https://drive.google.com/file/d/1MOzGvpLTdl84cEqwrA6MtrTWudjnRiYF/view?usp=sharing"
     ],
     "References": [
         {

--- a/bounties/packagist/ampache/1/vulnerability.json
+++ b/bounties/packagist/ampache/1/vulnerability.json
@@ -1,0 +1,59 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-09-13",
+    "AffectedVersionRange": "*",
+    "Summary": "Lack of Rate Limiting",
+    "Contributor": {
+        "Discloser": "Anon-Artist",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "packagist",
+        "Name": "ampache",
+        "URL": "http://ampache.org",
+        "Downloads": ""
+    },
+    "CWEs": [
+        {
+            "ID": "CWE-307",
+            "Description": "Lack of Rate Limiting at login page"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.3"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/ampache/ampache",
+        "Codebase": [
+            "PHP"
+        ],
+        "Owner": "ampache",
+        "Name": "ampache",
+        "Forks": 496,
+        "Stars": 2503
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}


### PR DESCRIPTION
## ✍️ Description
Lack of RateLimiting in the login page of ampache.
## 🕵️‍♂️ Proof of Concept 
* clone the github repo 
* setted up ampache platform to reproduce the vulnerability
* I used an intruder in BURP SUITE to test for rate limiting on the password field.
* It shows 200 OK for wrong information and if password matches BURP show a 302 status code.(even with high thread and without throttle)

* https://drive.google.com/file/d/1MOzGvpLTdl84cEqwrA6MtrTWudjnRiYF/view?usp=sharing

## 💥 Impact
The attacker is able to perform bruteforce attack to login into victim account.
## ✅ Checklist
- [x] _Created and populated the README.md and vulnerability.json files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_

