### PR TITLE
Bypassing ratelimiting   traduora

### DIFF
--- a/bounties/other/traduora/3/README.md
+++ b/bounties/other/traduora/3/README.md
@@ -1,6 +1,6 @@
-## ✍️ Description
+# Description
 Lack of RateLimiting in the login page of traduora.
-## 🕵️‍♂️ Proof of Concept 
+# Proof of Concept 
 * clone the github repo 
 * setted up traduora platform to reproduce the vulnerability
 * I used an intruder in BURP SUITE to test for rate limiting on the password field.
@@ -10,13 +10,5 @@ Lack of RateLimiting in the login page of traduora.
 [POC of Error] https://drive.google.com/file/d/1KpnPcAWBf8SoMJDL7bJp12ZCLxSGjopE/view?usp=sharing
 [POC of bypassing ratelimiting] https://drive.google.com/file/d/1hQjLPbJ1lS5rKWv-I8Gv3wi0DOTjX9K2/view?usp=sharing
 
-## 💥 Impact
+# Impact
 The attacker is able to perform bruteforce attack in login into victim account.
-## ✅ Checklist
-- [x] _Created and populated the README.md and vulnerability.json files_
-- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
-- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
-- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
-- [x] _Checked that the vulnerability affects the latest version of the package released_
-- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
-- [x] _Complied with all applicable laws_

--- a/bounties/other/traduora/3/README.md
+++ b/bounties/other/traduora/3/README.md
@@ -1,0 +1,22 @@
+## ✍️ Description
+Lack of RateLimiting in the login page of traduora.
+## 🕵️‍♂️ Proof of Concept 
+* clone the github repo 
+* setted up traduora platform to reproduce the vulnerability
+* I used an intruder in BURP SUITE to test for rate limiting on the password field.
+* In normal intruder function it shows status code 429 that is ratelimit function is there
+* To bypass it use intruder with throttle above 700 and use thread 100+ , for wrong password it shows 401 errror if right password comes it shows 200 error.
+
+[POC of Error] https://drive.google.com/file/d/1KpnPcAWBf8SoMJDL7bJp12ZCLxSGjopE/view?usp=sharing
+[POC of bypassing ratelimiting] https://drive.google.com/file/d/1hQjLPbJ1lS5rKWv-I8Gv3wi0DOTjX9K2/view?usp=sharing
+
+## 💥 Impact
+The attacker is able to perform bruteforce attack in login into victim account.
+## ✅ Checklist
+- [x] _Created and populated the README.md and vulnerability.json files_
+- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
+- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
+- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
+- [x] _Checked that the vulnerability affects the latest version of the package released_
+- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
+- [x] _Complied with all applicable laws_

--- a/bounties/other/traduora/3/vulnerability.json
+++ b/bounties/other/traduora/3/vulnerability.json
@@ -1,0 +1,60 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-09-13",
+    "AffectedVersionRange": "0.17.0",
+    "Summary": "Lack of Rate Limiting",
+    "Contributor": {
+        "Discloser": "Anon-Artist",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "other",
+        "Name": "traduora",
+        "URL": "https://github.com/traduora/traduora",
+        "Downloads": ""
+    },
+    "CWEs": [
+        {
+            "ID": "CWE-307",
+            "Description": "Bypassing Rate Limiting at login page"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.3"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/traduora/traduora",
+        "Codebase": [
+            "other"
+        ],
+        "Owner": "traduora",
+        "Name": "traduora",
+        "Forks": 93,
+        "Stars": 1263
+    },
+    "Permalinks": [
+        "https://drive.google.com/file/d/1KpnPcAWBf8SoMJDL7bJp12ZCLxSGjopE/view?usp=sharing",
+	      "https://drive.google.com/file/d/1hQjLPbJ1lS5rKWv-I8Gv3wi0DOTjX9K2/view?usp=sharing"
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}

--- a/bounties/other/traduora/3/vulnerability.json
+++ b/bounties/other/traduora/3/vulnerability.json
@@ -1,5 +1,5 @@
 {
-    "PackageVulnerabilityID": "1",
+    "PackageVulnerabilityID": "3",
     "DisclosureDate": "2020-09-13",
     "AffectedVersionRange": "0.17.0",
     "Summary": "Lack of Rate Limiting",

--- a/bounties/other/traduora/3/vulnerability.json
+++ b/bounties/other/traduora/3/vulnerability.json
@@ -15,7 +15,7 @@
     },
     "CWEs": [
         {
-            "ID": "CWE-307",
+            "ID": "307",
             "Description": "Bypassing Rate Limiting at login page"
         }
     ],
@@ -49,7 +49,7 @@
     },
     "Permalinks": [
         "https://drive.google.com/file/d/1KpnPcAWBf8SoMJDL7bJp12ZCLxSGjopE/view?usp=sharing",
-	      "https://drive.google.com/file/d/1hQjLPbJ1lS5rKWv-I8Gv3wi0DOTjX9K2/view?usp=sharing"
+	"https://drive.google.com/file/d/1hQjLPbJ1lS5rKWv-I8Gv3wi0DOTjX9K2/view?usp=sharing"
     ],
     "References": [
         {

--- a/bounties/other/traduora/3/vulnerability.json
+++ b/bounties/other/traduora/3/vulnerability.json
@@ -16,7 +16,7 @@
     "CWEs": [
         {
             "ID": "307",
-            "Description": "Bypassing Rate Limiting at login page"
+            "Description": "Improper Restriction of Excessive Authentication Attempts"
         }
     ],
     "CVSS": {
@@ -40,7 +40,7 @@
     "Repository": {
         "URL": "https://github.com/traduora/traduora",
         "Codebase": [
-            "other"
+            "JavaScript"
         ],
         "Owner": "traduora",
         "Name": "traduora",


### PR DESCRIPTION
## ✍️ Description
Lack of RateLimiting in the login page of traduora.
## 🕵️‍♂️ Proof of Concept 
* clone the github repo 
* setted up traduora platform to reproduce the vulnerability
* I used an intruder in BURP SUITE to test for rate limiting on the password field.
* In normal intruder function it shows status code 429 that is ratelimit function is there
* To bypass it use intruder with throttle above 700 and use thread 100+ , for wrong password it shows 401 errror if right password comes it shows 200 error.

[POC of Error] https://drive.google.com/file/d/1KpnPcAWBf8SoMJDL7bJp12ZCLxSGjopE/view?usp=sharing
[POC of bypassing ratelimiting] https://drive.google.com/file/d/1hQjLPbJ1lS5rKWv-I8Gv3wi0DOTjX9K2/view?usp=sharing

## 💥 Impact
The attacker is able to perform bruteforce attack in login into victim account.
## ✅ Checklist
- [x] _Created and populated the README.md and vulnerability.json files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_
