### PR TITLE
Insecure File Download in NixOS

### DIFF
--- a/bounties/other/NixOS/1/README.md
+++ b/bounties/other/NixOS/1/README.md
@@ -1,0 +1,2 @@
+# Description
+Nixpkgs is a collection of over 40,000 software packages that can be installed with the Nix package manager. It also implements NixOS, a purely-functional Linux distribution.This package is vulnerable to ```MITM``` or ```Man-In-The-Middle``` attack due to a downloading resources through insecure protocols. It is possible for an attacker to intercept and alter the packages which may leads to RCE / other attacks which may help the attacker gain access to host.

--- a/bounties/other/NixOS/1/vulnerability.json
+++ b/bounties/other/NixOS/1/vulnerability.json
@@ -1,0 +1,49 @@
+
+{
+  "PackageVulnerabilityID": "1",
+  "DisclosureDate": "2020-09-17",
+  "AffectedVersionRange": "*",
+  "Summary": "Resource Download Over Insecure Protocol",
+  "Contributor": {
+    "Discloser": "melissa-max",
+    "Fixer": ""
+  },
+  "Package": {
+    "Registry": "Other",
+    "Name": "",
+    "URL": ""
+  },
+  "CWEs": [
+    {
+      "ID": "CWE-494",
+      "Description": "Download of Code Without Integrity Check"
+    }
+  ],
+  "CVSS": {
+    "Version": "3.1",
+    "AV": "",
+    "AC": "",
+    "PR": "",
+    "UI": "",
+    "S": "",
+    "C": "",
+    "I": "",
+    "A": "",
+    "E": "",
+    "RL": "",
+    "RC": "",
+    "Score": "5.0"
+  },
+  "CVEs": [""],
+  "Repository": {
+    "URL": "https://github.com/NixOS/nixpkgs",
+    "Codebase": ["Nix"]
+  },
+  "Permalinks": ["https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/mailreaders/thunderbird-bin/68_sources.nix"],
+  "References": [
+    {
+      "Description": "",
+      "URL": ""
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for contributing to huntr! -->

## ✍️ Description

Nixpkgs is a collection of over 40,000 software packages that can be installed with the Nix package manager. It also implements NixOS, a purely-functional Linux distribution.This package is vulnerable to ```MITM``` or ```Man-In-The-Middle``` attack due to a downloading resources through insecure protocols. It is possible for an attacker to intercept and alter the packages which may leads to RCE / other attacks which may help the attacker gain access to host.

## Impact
An attacker could modify the contents of the file since the download is through an insecure HTTP channel. There is no functionality implemented to verify the authenticity of the downloaded file.

## :white_check_mark: Checklist
**In my pull request, I have:**

- [x] _Created and populated the `README.md` and `vulnerability.json` files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_
