### PR TITLE
local-file-inclusion in PHPMailer 

### DIFF
--- a/bounties/packagist/PHPMailer/PHPMailer/1/README.md
+++ b/bounties/packagist/PHPMailer/PHPMailer/1/README.md
@@ -1,0 +1,15 @@
+### Description
+PHPMailer is a PHP Library for sending email.
+
+This package is vulnerable to Local File Disclosure. The `addAttachment` method allows user input for a file path. Hence, attacker has full control of the path that it can bruteforce its way to even attach a file that belongs to the OS. for example, in Linux, it can even access `/etc/passwd` file.
+
+### POC
+1. Create a project dir in your htdocs folder
+2. Install the package using composer. [here](https://github.com/PHPMailer/PHPMailer#installation--loading)
+3. Create a test.php file on your project root dir
+4. Copy and paste the sample code from the package. [here](https://github.com/PHPMailer/PHPMailer#a-simple-example)
+5. Configure the SMTP credentials
+6. On method `addAttachment`, add any file. for ex, in linux, use '/etc/passwd' as the method parameter
+7. Open terminal in your project root dir, then run command `php test.php`
+8. Check your inbox for the email
+9. Now, you can download the attached file

--- a/bounties/packagist/PHPMailer/PHPMailer/1/vulnerability.json
+++ b/bounties/packagist/PHPMailer/PHPMailer/1/vulnerability.json
@@ -1,0 +1,48 @@
+{
+  "PackageVulnerabilityID": "1",
+  "DisclosureDate": "2020-10-28",
+  "AffectedVersionRange": "*",
+  "Summary": "Local File Inclusion",
+  "Contributor": {
+    "Discloser": "nikkolai14",
+    "Fixer": ""
+  },
+  "Package": {
+    "Registry": "packagist",
+    "Name": "phpmailer/phpmailer",
+    "URL": "https://packagist.org/packages/phpmailer/phpmailer"
+  },
+  "CWEs": [
+    {
+      "ID": "22",
+      "Description": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+    }
+  ],
+  "CVSS": {
+    "Version": "3.1",
+    "AV": "L",
+    "AC": "L",
+    "PR": "N",
+    "UI": "R",
+    "S": "U",
+    "C": "L",
+    "I": "N",
+    "A": "N",
+    "E": "X",
+    "RL": "X",
+    "RC": "X",
+    "Score": "3.3"
+  },
+  "CVEs": [""],
+  "Repository": {
+    "URL": "https://github.com/PHPMailer/PHPMailer",
+    "Codebase": ["PHP"]
+  },
+  "Permalinks": ["https://github.com/PHPMailer/PHPMailer/blob/master/src/PHPMailer.php#L2996"],
+  "References": [
+    {
+      "Description": "",
+      "URL": ""
+    }
+  ]
+}


### PR DESCRIPTION
## ✍️ Description

The PHP Library PHPMailer is vulnerable to local file inclusion when attaching a file path.

## 🕵️‍♂️ Proof of Concept

1. Create a project dir in your htdocs folder
2. Install the package using composer. [here](https://github.com/PHPMailer/PHPMailer#installation--loading)
3. Create a test.php file on your project root dir
4. Copy and paste the sample code from the package. [here](https://github.com/PHPMailer/PHPMailer#a-simple-example)
5. Configure the SMTP credentials
6. On method `addAttachment`, add any file. for ex, in linux, use '/etc/passwd' as the method parameter
7. Open terminal in your project root dir, then run command `php test.php`
8. Check your inbox for the email
9. Now, you can download the attached file

## 💥 Impact

Attacker can get sensitive file from the webapp server such as .env files which lists all credentials such as db configs, email smtp and etc.


## ☎️ Contact

Nope

## ✅ Checklist

**In my pull request, I have:**

- [x ] _Created and populated the `README.md` and `vulnerability.json` files_
- [x ] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x ] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [ x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [ x] _Checked that the vulnerability affects the latest version of the package released_
- [ x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [ x] _Complied with all applicable laws_
