### PR TITLE
IDOR leading to Privilege Escalation

### DIFF
--- a/bounties/packagist/dolibarr/dolibarr/7/README.md
+++ b/bounties/packagist/dolibarr/dolibarr/7/README.md
@@ -1,4 +1,4 @@
-# Description
+# Description 
 
 Dolibarr is vulnerable to an IDOR vulnerability which can lead to Privilege Escalation. 
 

--- a/bounties/packagist/dolibarr/dolibarr/7/README.md
+++ b/bounties/packagist/dolibarr/dolibarr/7/README.md
@@ -4,7 +4,7 @@ Dolibarr is vulnerable to an IDOR vulnerability which can lead to Privilege Esca
 
 # Proof of Concept
 
-1.Download and Install Dolibarr form [Dolibarr](https://github.com/Dolibarr/dolibarr/) 
+1.Download and Install Dolibarr from [Dolibarr](https://github.com/Dolibarr/dolibarr/) 
 
 2.Create two New users with the following permissions(let the new user be SAM and John)      
    -Delete or disable other users    

--- a/bounties/packagist/dolibarr/dolibarr/7/README.md
+++ b/bounties/packagist/dolibarr/dolibarr/7/README.md
@@ -1,0 +1,29 @@
+# Description
+
+Dolibarr is vulnerable to an IDOR vulnerability which can lead to Privilege Escalation. 
+
+# Proof of Concept
+
+1.Download and Install Dolibarr form [Dolibarr](https://github.com/Dolibarr/dolibarr/) 
+
+2.Create two New users with the following permissions(let the new user be SAM and John)      
+   -Delete or disable other users    
+   -Read other users and groups  
+  
+3.Now Login as the new user(SAM).Sam just have the permission to Disable other users other than admins.The Disable button is not avilable for admin profiles.
+
+4.Now visit Johns profile by Clicking List of user,You will find a disable button to disable John's profile. Click on it and intercept the request . A request similar to the 
+snippet will be made
+
+```
+GET /user/card.php?action=disable&id=4 HTTP/1.1
+Host: localhost/
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+Connection: close
+```
+5:Replace the ``&id=`` parameter with the ID of Admin.
+
+The Super-admin gets disabled.

--- a/bounties/packagist/dolibarr/dolibarr/7/vulnerability.json
+++ b/bounties/packagist/dolibarr/dolibarr/7/vulnerability.json
@@ -1,0 +1,57 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2021-01-11",
+    "AffectedVersionRange": "*",
+    "Summary": "Insecure direct object references",
+    "Contributor": {
+        "Discloser": "tibinsunny",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "packagist",
+        "Name": "dolibarr/dolibarr",
+        "URL": "https://github.com/Dolibarr/dolibarr/",
+        "Downloads": "2200"
+    },
+    "CWEs": [
+        {
+            "ID": "200",
+            "Description": " insecure direct object reference"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "6.1"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/Dolibarr/dolibarr/",
+        "Codebase": [
+            "php"
+        ],
+        "Owner": "Dolibarr",
+        "Name": "dolibarr"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}

--- a/bounties/packagist/dolibarr/dolibarr/7/vulnerability.json
+++ b/bounties/packagist/dolibarr/dolibarr/7/vulnerability.json
@@ -9,7 +9,7 @@
     },
     "Package": {
         "Registry": "packagist",
-        "Name": "dolibarr/dolibarr",
+        "Name": "dolibarr",
         "URL": "https://github.com/Dolibarr/dolibarr/",
         "Downloads": "2200"
     },


### PR DESCRIPTION
### ✍️ **Description**
`Dolibarr` is vulnerable to an IDOR vulnerability which can lead to Privilege Escalation.


### 🕵️‍♂️ Proof of Concept
1.Download and Install Dolibarr from [Dolibarr](https://github.com/Dolibarr/dolibarr/) 

2.Create two New users with the following permissions(let the new user be SAM and John)      
   -Delete or disable other users    
   -Read other users and groups  

3.Now Login as the new user(SAM).Sam just have the permission to Disable other users other than admins.The Disable button is not avilable for admin profiles.

4.Now visit Johns profile by Clicking `List of user ` in the left panel,You will find a disable button to disable John's profile. Click on it and intercept the request . A request similar to the 
snippet will be made

```
GET /user/card.php?action=disable&id=4 HTTP/1.1
Host: localhost/
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: close
```
5.Replace the ``&id=`` parameter with the ID of Admin.

I know the steps are a bit complicated. Incase if you get stuck somewhere feel free to ping me 😅

### Impact
A normal user can kick the super admin out of the platform and ,if the there is only one super admin then no one will be able to manage the Platform after.


### ✅ Checklist 
- [x] Created and populated the README.md and vulnerability.json files  
- [x] Provided the repository URL and any applicable permalinks
- [x] Defined all the applicable weaknesses (CWEs)
- [x] Proposed the CVSS vector items i.e. User Interaction, Attack Complexity
- [x] Checked that the vulnerability affects the latest version of the package released
- [x] Checked that a fix does not currently exist that remediates this vulnerability
- [x] Complied with all applicable laws