### PR TITLE
Papermerge XSS Via Filename Due To Insecure Errors Reflections

### DIFF
--- a/bounties/pip/papermerge/2/README.md
+++ b/bounties/pip/papermerge/2/README.md
@@ -1,0 +1,13 @@
+# :star2: Description
+- Papermerge is an open source document management system (DMS) primarily designed for archiving and retrieving your digital documents. Instead of having piles of paper documents all over your desk, office or drawers. In The Admin Upload Function. Users Are Able To Trigger Cross-Site Scripting (XSS) Via XSS Payload On The Filename Due To Lack Of User Input Filter While Viewing Error Messages.
+
+## :bust_in_silhouette: Steps To Reproduce:
+- Open Papermerge [Demo Instance](https://demo.papermerge.com/#5) Or You Own Instance With `/#{ANY-NUMBER}`
+- You Will Find a Button With `Upload` Word On It.
+- Create a Simple File On Your Machine With XSS Payload: `<img src=x onerror=confirm(1)>.jpeg`
+- Try To Upload That File To The Instance. And The XSS Will Be Triggered.
+
+## :boom: Proof Of Concept:
+![ProofOfConcept](https://im6.ezgif.com/tmp/ezgif-6-991cae4f1b62.gif)
+
+Regards.

--- a/bounties/pip/papermerge/2/vulnerability.json
+++ b/bounties/pip/papermerge/2/vulnerability.json
@@ -2,6 +2,7 @@
 	"PackageVulnerabilityID": "2",
 	"DisclosureDate": "2021-02-12",
 	"AffectedVersionRange": "*",
+	"Contributor": {},
 	"Summary": "Cross-Site Scripting (XSS)",
 	"Package": {
 		"Registry": "pip",
@@ -47,5 +48,6 @@
 	"References": [{
 		"Description": "",
 		"URL": ""
-	}]
+	}],
+	"PrNumber": "1866"
 }

--- a/bounties/pip/papermerge/2/vulnerability.json
+++ b/bounties/pip/papermerge/2/vulnerability.json
@@ -1,0 +1,44 @@
+{
+    "PackageVulnerabilityID": "2",
+    "DisclosureDate": "2021-02-12",
+    "AffectedVersionRange": "*",
+    "Summary": "Cross-Site Scripting (XSS)",
+    },
+    "Package": {
+        "Registry": "pip",
+        "Name": "papermerge",
+        "URL": "https://pypi.org/project/papermerge",
+        "Downloads": "3"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Cross-Site Scripting (XSS)"
+        }
+    ],
+    "CVSS": {
+        ""
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/ciur/papermerge",
+        "Codebase": [
+            "Python"
+        ],
+        "Owner": "ciur",
+        "Name": "papermerge",
+        "Stars": "990",
+        "Forks": "122"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ],
+}

--- a/bounties/pip/papermerge/2/vulnerability.json
+++ b/bounties/pip/papermerge/2/vulnerability.json
@@ -1,44 +1,51 @@
 {
-    "PackageVulnerabilityID": "2",
-    "DisclosureDate": "2021-02-12",
-    "AffectedVersionRange": "*",
-    "Summary": "Cross-Site Scripting (XSS)",
-    },
-    "Package": {
-        "Registry": "pip",
-        "Name": "papermerge",
-        "URL": "https://pypi.org/project/papermerge",
-        "Downloads": "3"
-    },
-    "CWEs": [
-        {
-            "ID": "471",
-            "Description": "Cross-Site Scripting (XSS)"
-        }
-    ],
-    "CVSS": {
-        ""
-    },
-    "CVEs": [
-        ""
-    ],
-    "Repository": {
-        "URL": "https://github.com/ciur/papermerge",
-        "Codebase": [
-            "Python"
-        ],
-        "Owner": "ciur",
-        "Name": "papermerge",
-        "Stars": "990",
-        "Forks": "122"
-    },
-    "Permalinks": [
-        ""
-    ],
-    "References": [
-        {
-            "Description": "",
-            "URL": ""
-        }
-    ],
+	"PackageVulnerabilityID": "2",
+	"DisclosureDate": "2021-02-12",
+	"AffectedVersionRange": "*",
+	"Summary": "Cross-Site Scripting (XSS)",
+	"Package": {
+		"Registry": "pip",
+		"Name": "papermerge",
+		"URL": "https://pypi.org/project/papermerge",
+		"Downloads": "3"
+	},
+	"CWEs": [{
+		"ID": "471",
+		"Description": "Cross-Site Scripting (XSS)"
+	}],
+	"CVSS": {
+		"Version": "3.0",
+		"AV": "N",
+		"AC": "L",
+		"PR": "H",
+		"UI": "R",
+		"S": "C",
+		"C": "L",
+		"I": "L",
+		"A": "N",
+		"E": "",
+		"RL": "",
+		"RC": "",
+		"Score": "4.8"
+	},
+	"CVEs": [
+		""
+	],
+	"Repository": {
+		"URL": "https://github.com/ciur/papermerge",
+		"Codebase": [
+			"Python"
+		],
+		"Owner": "ciur",
+		"Name": "papermerge",
+		"Stars": "990",
+		"Forks": "122"
+	},
+	"Permalinks": [
+		""
+	],
+	"References": [{
+		"Description": "",
+		"URL": ""
+	}]
 }


### PR DESCRIPTION
## ✍️ Description
- On Papermerge, XSS is Possible Using The Filename That Got Returned Back To The User On The Error Messages. The Error Messages Viewer Doesn't Filter The User Input That Allows Executing HTML/JS Codes Inside Of It. But It Requires The User To Upload The File With The Payload On The Filename.

## 🕵️‍♂️ Proof of Concept
![ProofOfConcept](https://im6.ezgif.com/tmp/ezgif-6-991cae4f1b62.gif)

## 💥 Impact
- Cross-Site Scripting Could Allow Attackers To Steal Users Information And Secrets. Phishing. Other Stuff.

## ☎️ Contact
- No, I Didn't Contact The Package Author.

## ✅ Checklist
**In my pull request, I have:**

- [X] _Created and populated the `README.md` and `vulnerability.json` files_
- [X] _Provided the repository URL and any applicable [permalinks]([https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files](https://help.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files))_
- [X] _Defined all the applicable weaknesses ([CWEs]([https://cwe.mitre.org/](https://cwe.mitre.org/)))_
- [x] _Proposed the CVSS vector items i.e. User Interaction, Attack Complexity_
- [X] _Checked that the vulnerability affects the latest version of the package released_
- [X] _Checked that a fix does not currently exist that remediates this vulnerability_
- [X] _Complied with all applicable laws_
