### PR TITLE
Fixing Someone Issue Typo On The Summary - Marking XSS as SSRF.

### DIFF
--- a/bounties/other/docs/1/vulnerability.json
+++ b/bounties/other/docs/1/vulnerability.json
@@ -2,7 +2,7 @@
     "PackageVulnerabilityID": "1",
     "DisclosureDate": "2021-02-06",
     "AffectedVersionRange": "*",
-    "Summary": "SSRF",
+    "Summary": "XSS",
     "Contributor": {
         "Discloser": "36979660",
         "Fixer": ""


### PR DESCRIPTION
- Someone Did Add Invalid Summary For XSS Issue And Marked It as XSS. Fixing This.