### PR TITLE
Denial Of Service On Shupload Server Due To Lack Of Image Size Validation Can Fill-Up The Server Storage.

### DIFF
--- a/bounties/other/shupload/2/README.md
+++ b/bounties/other/shupload/2/README.md
@@ -1,0 +1,14 @@
+# :dizzy: Description:
+- Shupload Is a Personal image hosting and sharing by the power of HTTP, Go, and an optional bit of JavaScript. Due To Lack Of Image Size Validation. Remote Attackers Are Able To Store Big Images Inside The Database Folder That Will Fill Up The Space And The Hall System Won't Work Anymore Since There's No Space Left To Right On. Could Easly Exploited Using Bash Loop For 15 Minutes To Fill Up To 1000GB+ Of Data That Can Make Any Machine Out-Of-Space.
+
+# :ok_hand: Steps To Reproduce:
+- Install Your Shupload Instance, Then Run It From The Binary.
+- Download a Big Image. In My Case It's 90+mb Image.
+- Use This cURL Command To Upload The Image: `curl -X POST -H "Content-Type: multipart/form-data" -F "file=@{IMAGE-FILENAME}" http://{HOST:PORT}/`
+- Keep Executing This Command Multiple Times Then See Your `db` Folder Space Using `du -sh db/`
+- You Will Find That It's Space Is Really Big Depending On The Number Of Times You Executed The Command.
+
+# :boom: Proof Of Concept:
+- Just Follow Steps To Reproduce On Your Own Insatance. I Won't Perform a DoS Attack On My Own Instance While It's Used To Serve My Server.
+
+Cheers

--- a/bounties/other/shupload/2/vulnerability.json
+++ b/bounties/other/shupload/2/vulnerability.json
@@ -1,0 +1,59 @@
+{
+    "PackageVulnerabilityID": "2",
+    "DisclosureDate": "2021-02-14",
+    "AffectedVersionRange": "*",
+    "Contributor": {
+    },
+    "Summary": "Distributed denial of service",
+    "Package": {
+        "Registry":"other",
+        "Name":"shupload",
+        "URL":"https://github.com/kettek/shupload",
+        "Downloads":"0"
+    },
+    "CWEs": [
+        {
+            "ID": "400",
+            "Description": "Distributed denial of service"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.0",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "N",
+        "I": "N",
+        "A": "H",
+        "E": "F",
+        "RL": "X",
+        "RC": "X",
+        "Score": "7.5"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/kettek/shupload",
+        "Codebase": [
+            "Golang"
+        ],
+        "Owner": "kettek",
+        "Name": "shupload",
+        "Stars": "8",
+        "Forks": "2",
+        "ForkName": "shupload"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ],
+    "PrNumber": ""
+}


### PR DESCRIPTION
# :dizzy: Description:
- Shupload Is a Personal image hosting and sharing by the power of HTTP, Go, and an optional bit of JavaScript. Due To Lack Of Image Size Validation. Remote Attackers Are Able To Store Big Images Inside The Database Folder That Will Fill Up The Space And The Hall System Won't Work Anymore Since There's No Space Left To Right On. Could Easly Exploited Using Bash Loop For 15 Minutes To Fill Up To 1000GB+ Of Data That Can Make Any Machine Out-Of-Space.

# :ok_hand: Steps To Reproduce:
- Install Your Shupload Instance, Then Run It From The Binary.
- Download a Big Image. In My Case It's 90+mb Image.
- Use This cURL Command To Upload The Image: `curl -X POST -H "Content-Type: multipart/form-data" -F "file=@{IMAGE-FILENAME}" http://{HOST:PORT}/`
- Keep Executing This Command Multiple Times Then See Your `db` Folder Space Using `du -sh db/`
- You Will Find That It's Space Is Really Big Depending On The Number Of Times You Executed The Command.

# :boom: Proof Of Concept:
- Just Follow Steps To Reproduce On Your Own Insatance. I Won't Perform a DoS Attack On My Own Instance While It's Used To Serve My Server.

Cheers
