### PR TITLE
Symlink LFI in Discord-Recon

### DIFF
--- a/bounties/other/Discord-Recon/1/README.md
+++ b/bounties/other/Discord-Recon/1/README.md
@@ -1,0 +1,19 @@
+# Description:
+
+- Discord-Recon is vulnerable to LFI where remote attacker can escape the recon path and access external files in the system and read files outside the recon path in some cases. this issue happens due to improper symlink validation.
+
+# Steps to reproduce:
+
+1. Open your discord-server recon path
+2. Create a symlink that point to any local file
+3. Use `.recon` command and call this symlink file.
+
+# Proof Of Concept:
+
+Content of `etc/hostname` from @DEMON1A server.
+
+<img src=https://media.discordapp.net/attachments/813663937345749082/814462361129058304/unknown.png>
+
+# Impact:
+
+Remote low privilege attacker able to read content of the local files for the server.

--- a/bounties/other/Discord-Recon/1/vulnerability.json
+++ b/bounties/other/Discord-Recon/1/vulnerability.json
@@ -4,7 +4,7 @@
     "AffectedVersionRange": "*",
     "Contributor": {
         "Discloser":"",
-        "Fixer"
+        "Fixer":""
     },
     "Summary": "LFI",
     "Package": {

--- a/bounties/other/Discord-Recon/1/vulnerability.json
+++ b/bounties/other/Discord-Recon/1/vulnerability.json
@@ -1,0 +1,61 @@
+{
+    "PackageVulnerabilityID": "1",
+    "DisclosureDate": "2021-02-25",
+    "AffectedVersionRange": "*",
+    "Contributor": {
+        "Discloser":"",
+        "Fixer"
+    },
+    "Summary": "LFI",
+    "Package": {
+        "Registry":"other",
+        "Name":"Discord-Recon",
+        "URL":"https://github.com/DEMON1A/Discord-Recon",
+        "Downloads":""
+    },
+    "CWEs": [
+        {
+            "ID": "23",
+            "Description": "LFI"
+        }
+    ],
+    "CVSS": {
+        "Version": "3.0",
+        "AV": "N",
+        "AC": "H",
+        "PR": "N",
+        "UI": "N",
+        "S": "U",
+        "C": "H",
+        "I": "N",
+        "A": "N",
+        "E": "F",
+        "RL": "X",
+        "RC": "X",
+        "Score": "5.9"
+    },
+    "CVEs": [
+        ""
+    ],
+    "Repository": {
+        "URL": "https://github.com/DEMON1A/Discord-Recon",
+        "Codebase": [
+            "python"
+        ],
+        "Owner": "DEMON1A",
+        "Name": "Discord-Recon",
+        "Stars": "3",
+        "Forks": "0",
+        "ForkName": "Discord-Recon"
+    },
+    "Permalinks": [
+        ""
+    ],
+    "References": [
+        {
+            "Description": "",
+            "URL": ""
+        }
+    ],
+    "PrNumber": ""
+}


### PR DESCRIPTION
## ✍️ Description

- Discord-Recon is vulnerable to LFI where remote attacker can escape the recon path and access external files in the system and read files outside the recon path in some cases. this issue happens due to improper symlink validation.

## Steps to reproduce:

1. Open your discord-server recon path
2. Create a symlink that point to any local file
3. Use `.recon` command and call this symlink file.

## 🕵️‍♂️ Proof of Concept

https://github.com/DEMON1A/Discord-Recon

Content of `etc/hostname` from @DEMON1A server.

<img src=https://media.discordapp.net/attachments/813663937345749082/814462361129058304/unknown.png>

## 💥 Impact

Remote low privilege attacker able to read content of the local files for the server.

