### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within huntr, please submit a report via [huntr.dev](https://huntr.dev/repos/418sec/huntr). Bounties and CVEs are automatically managed and allocated via the platform.


### PR DESCRIPTION
As requested through the platform by @psmoros, this will point your security policy to [huntr.dev](https://huntr.dev/repos/418sec/huntr})